### PR TITLE
Add Work Experience section keeping the mac-os themed style intact

### DIFF
--- a/app/components/Desktop.tsx
+++ b/app/components/Desktop.tsx
@@ -1,4 +1,5 @@
-import { User , File, Mail, Briefcase } from 'lucide-react'
+import { User, File, Mail, Briefcase } from 'lucide-react'
+import { ClipboardList } from 'lucide-react' // ✅ New icon for Work Experience
 
 interface DesktopProps {
   toggleWindow: (id: string) => void
@@ -25,11 +26,16 @@ export default function Desktop({ toggleWindow }: DesktopProps) {
       id: 'resume',
       label: 'Resume',
       icon: <File className="w-5 h-5 sm:w-6 sm:h-6 text-black dark:text-white" />
+    },
+    {
+      id: 'work-experience', // ✅ Work Experience
+      label: 'Work Experience',
+      icon: <ClipboardList className="w-5 h-5 sm:w-6 sm:h-6 text-black dark:text-white" />
     }
   ]
 
   return (
-    <div className="absolute right-0 top-8 p-4 sm:flex flex-col gap-8  hidden">
+    <div className="absolute right-0 top-8 p-4 sm:flex flex-col gap-8 hidden">
       {icons.map(({ id, label, icon }) => (
         <button
           key={id}

--- a/app/components/Desktop.tsx
+++ b/app/components/Desktop.tsx
@@ -1,5 +1,5 @@
 import { User, File, Mail, Briefcase } from 'lucide-react'
-import { ClipboardList } from 'lucide-react' // ✅ New icon for Work Experience
+import { ClipboardList } from 'lucide-react' 
 
 interface DesktopProps {
   toggleWindow: (id: string) => void
@@ -28,7 +28,7 @@ export default function Desktop({ toggleWindow }: DesktopProps) {
       icon: <File className="w-5 h-5 sm:w-6 sm:h-6 text-black dark:text-white" />
     },
     {
-      id: 'work-experience', // ✅ Work Experience
+      id: 'work-experience', 
       label: 'Work Experience',
       icon: <ClipboardList className="w-5 h-5 sm:w-6 sm:h-6 text-black dark:text-white" />
     }

--- a/app/components/Dock.tsx
+++ b/app/components/Dock.tsx
@@ -10,6 +10,7 @@ import {
   Gamepad2 // Import Gamepad2 icon for the game
 } from 'lucide-react'
 import {  ReactNode } from 'react'
+import { ClipboardList } from 'lucide-react';
 
 
 interface DockItemProps {
@@ -101,6 +102,12 @@ export default function Dock({ toggleWindow }: DockProps) {
           <File className="w-5 h-5 sm:w-5 sm:h-5 text-gray-600/80 dark:text-white/80 
             group-hover:text-gray-900 dark:group-hover:text-white" />
         </DockItem>
+
+        <DockItem label="Work Experience" onClick={() => toggleWindow('work-experience')}>
+  <ClipboardList className="w-5 h-5 sm:w-5 sm:h-5 text-gray-600/80 dark:text-white/80 
+    group-hover:text-gray-900 dark:group-hover:text-white" />
+</DockItem>
+        
 
         {/* Added Pac-Man Game item */}
         <DockItem label="Pac-Man Game" onClick={() => toggleWindow('pacman-game')}>

--- a/app/components/WorkExperience.tsx
+++ b/app/components/WorkExperience.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+const WorkExperience: React.FC = () => {
+  return (
+    <div className="p-8 space-y-6">
+      <div className="bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 border border-gray-200 dark:border-gray-700 p-6 rounded-xl shadow-sm">
+        <h3 className="text-2xl font-bold mb-6 bg-gradient-to-r from-gray-700 to-gray-900 dark:from-gray-200 dark:to-gray-400 bg-clip-text text-transparent">
+          Work Experience
+        </h3>
+
+        <div className="space-y-6 text-gray-700 dark:text-gray-300">
+          {/* Experience 1 */}
+          <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4">
+            <h4 className="font-semibold text-gray-800 dark:text-gray-200">
+              Microsoft — Software Engineering Intern
+            </h4>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Summer 2025 | Bangalore, India
+            </p>
+            <ul className="mt-2 list-disc list-inside space-y-1 text-sm">
+              <li>Automated static analysis for GPU code</li>
+              <li>Developed RAG-based workflows for developer productivity</li>
+              <li>Improved CI/CD pipelines for large-scale projects</li>
+            </ul>
+          </div>
+
+          {/* Experience 2 */}
+          <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4">
+            <h4 className="font-semibold text-gray-800 dark:text-gray-200">
+              Open Food Facts — Open Source Contributor
+            </h4>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Feb 2025 – June 2025 | Remote
+            </p>
+            <ul className="mt-2 list-disc list-inside space-y-1 text-sm">
+              <li>Worked on CI/CD automation and feature development</li>
+              <li>Improved data ingestion pipelines for 1M+ product entries</li>
+              <li>Collaborated with a global open-source community</li>
+            </ul>
+          </div>
+
+          {/* Experience 3 */}
+          <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4">
+            <h4 className="font-semibold text-gray-800 dark:text-gray-200">
+              Global Psychological Services — Freelancer
+            </h4>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Oct 2024 – Jan 2025 | Remote
+            </p>
+            <ul className="mt-2 list-disc list-inside space-y-1 text-sm">
+              <li>Built Drishti Assessment Platform serving 2,500+ users</li>
+              <li>Designed secure authentication & analytics dashboards</li>
+              <li>Optimized platform performance and scalability</li>
+            </ul>
+          </div>
+
+          {/* Experience 4 */}
+          <div className="border-l-4 border-gray-300 dark:border-gray-600 pl-4">
+            <h4 className="font-semibold text-gray-800 dark:text-gray-200">
+              Freelance Projects & Hackathons
+            </h4>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              2023 – Present
+            </p>
+            <ul className="mt-2 list-disc list-inside space-y-1 text-sm">
+              <li>Developed multiple full-stack web applications</li>
+              <li>Won awards in GenAI, MongoDB, and blockchain hackathons</li>
+              <li>Mentored juniors in open-source contributions</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkExperience;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,25 +25,21 @@ import ProfileCard from "./components/AboutMe";
 import ConnectWithMe from "./components/Social";
 import Projects from "./components/Project";
 import PacManGame from "./components/PacManGame";
-
+import WorkExperience from "./components/WorkExperience"; // ✅ Import WorkExperience
 
 export default function Home() {
   const [openWindows, setOpenWindows] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [wallpaper1, setWallpaper] = useState(wallpaper); // Default wallpaper
 
-  // Array of wallpapers
-  const wallpapers = [wallpaper, wallpaper2,wallpaper3,wallpaper4,wallpaper5,wallpaper7,wallpaper8,wallpaper9,wallpaper10];
+  const wallpapers = [wallpaper, wallpaper2, wallpaper3, wallpaper4, wallpaper5, wallpaper7, wallpaper8, wallpaper9, wallpaper10];
 
-  // Function to toggle between wallpapers
   const switchWallpaper = (wallpaperSrc: string) => {
-    
     const selectedWallpaper = wallpapers.find((wallpaper) => wallpaper.src === wallpaperSrc);
     if (selectedWallpaper) {
-      setWallpaper(selectedWallpaper); // Assuming setWallpaper is a state setter for the current wallpaper
+      setWallpaper(selectedWallpaper);
     }
   };
-  
 
   const toggleWindow = (id: string) => {
     setOpenWindows((prev) =>
@@ -51,7 +47,6 @@ export default function Home() {
     );
   };
 
-  // Function to handle Cmd + T event
   const handleKeyDown = (event: KeyboardEvent) => {
     if ((event.metaKey || event.ctrlKey) && event.key === "t") {
       toggleWindow("terminal");
@@ -63,12 +58,10 @@ export default function Home() {
       setIsLoading(false);
     }, 10000);
 
-    // Adding the keydown event listener for Cmd + T
     window.addEventListener("keydown", handleKeyDown);
 
     return () => {
       clearTimeout(timer);
-      // Cleanup the event listener when the component unmounts
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, []);
@@ -77,9 +70,7 @@ export default function Home() {
     <ThemeProvider>
       <div
         className="min-h-screen min-w-full overflow-hidden bg-cover bg-center text-black dark:text-white transition-colors duration-300"
-        style={{
-          backgroundImage: `url(${wallpaper1.src})`,
-        }}
+        style={{ backgroundImage: `url(${wallpaper1.src})` }}
       >
         {isLoading ? (
           <ApplePreloader />
@@ -87,6 +78,8 @@ export default function Home() {
           <>
             <MenuBar switchWallpaper={switchWallpaper} />
             <Desktop toggleWindow={toggleWindow} />
+
+            {/* About Me */}
             {openWindows.includes("about") && (
               <Window
                 id="about"
@@ -96,6 +89,19 @@ export default function Home() {
                 <ProfileCard />
               </Window>
             )}
+
+            {/* Work Experience ✅ */}
+            {openWindows.includes("work-experience") && (
+              <Window
+                id="work-experience"
+                title="Work Experience"
+                onClose={() => toggleWindow("work-experience")}
+              >
+                <WorkExperience />
+              </Window>
+            )}
+
+            {/* Projects */}
             {openWindows.includes("projects") && (
               <Window
                 id="projects"
@@ -105,6 +111,8 @@ export default function Home() {
                 <Projects />
               </Window>
             )}
+
+            {/* Contact */}
             {openWindows.includes("contact") && (
               <Window
                 id="contact"
@@ -114,6 +122,8 @@ export default function Home() {
                 <ConnectWithMe />
               </Window>
             )}
+
+            {/* VS Code */}
             {openWindows.includes("vscode") && (
               <Window
                 id="vscode"
@@ -123,6 +133,8 @@ export default function Home() {
                 <VSCodeEditor />
               </Window>
             )}
+
+            {/* Browser */}
             {openWindows.includes("browser") && (
               <Window
                 id="browser"
@@ -132,6 +144,8 @@ export default function Home() {
                 <GeminiChat />
               </Window>
             )}
+
+            {/* Terminal */}
             {openWindows.includes("terminal") && (
               <Window
                 id="terminal"
@@ -141,6 +155,8 @@ export default function Home() {
                 <Terminal />
               </Window>
             )}
+
+            {/* Music Player */}
             {openWindows.includes("music-player") && (
               <Window
                 id="music-player"
@@ -150,9 +166,13 @@ export default function Home() {
                 <MusicPlayer />
               </Window>
             )}
+
+            {/* Resume */}
             {openWindows.includes("resume") && (
               <ResumeWindow onClose={() => toggleWindow("resume")} />
             )}
+
+            {/* Pac-Man Game */}
             {openWindows.includes("pacman-game") && (
               <Window
                 id="pacman-game"
@@ -162,9 +182,8 @@ export default function Home() {
                 <PacManGame />
               </Window>
             )}
+
             <Dock toggleWindow={toggleWindow} />
-            {/* Button to switch wallpaper */}
-            
           </>
         )}
       </div>


### PR DESCRIPTION
PR Description:

Summary:
This PR adds a new Work Experience section to the portfolio site. Users can now access the Work Experience window from both the Dock and the Desktop sidebar.

Changes Made:

Created WorkExperience.tsx component (TSX) with professional experience details.

Added Work Experience icon to the Dock (below Resume) using lucide-react’s ClipboardList icon.

Added Work Experience icon to the Desktop sidebar for quick access.

Updated Home.tsx to handle opening/closing the Work Experience window.

Ensured styling and animations match existing Dock/Desktop components.

Testing:

Verified the Work Experience window opens/closes correctly.

Checked other windows (About, Projects, Resume) for layout or style regressions.

Responsive design works on mobile and desktop screens.

Impact:

Enhances portfolio by showcasing professional experience.

Fully integrated with current site navigation and UI/UX.



https://github.com/user-attachments/assets/677fceaa-3769-4d63-a1d6-41ffde4c57f0

